### PR TITLE
Fixes #2: workaround/fix for the iOS 13 image duplication issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,28 @@
 # LDAlignmentImageView
 UIImageView subclass with simple methods to align and scale image inside UIImageView.
 
-##Demo:
+## Demo:
 ![](https://github.com/LucasssD/LDAlignmentImageView/blob/master/demo.gif)
 
-##Available properties:
+## Available properties:
 
--imageVerticalAlignment (Top, Center, Bottom)
+- `correctImage` (`UIImage`; use this instead of the standard `UIImageView`’s `image` property)
 
--imageHorizontalAlignment (Left, Center, Right)
+- `imageVerticalAlignment` (Top, Center, Bottom)
+
+- `imageHorizontalAlignment` (Left, Center, Right)
   
--imageContentMode (Original size, Scale to Fill, Scale Aspect Fill, Scale Aspect Fit)
+- `imageContentMode` (Original size, Scale to Fill, Scale Aspect Fill, Scale Aspect Fit)
 
+__Note:__ the example has not been updated to include the image duplication fix for iOS 13.
 
-##Animatable
+## Animatable
 All changes can be easly animated by putting them in animation block, for example
 
-    [UIView animateWithDuration:0.4  animations:^{
-        ldImageAlignmentView.imageVerticalAlignment = LDImageVerticalAlignmentCenter;
-        ldImageAlignmentView.imageHorizontalAlignment= LDImageHorizontalAlignmentLeft;
-        ldImageAlignmentView.imageContentMode = LDImageContentModeScaleToFill;
-    }];
-    
-
+```objective-c
+[UIView animateWithDuration:0.4  animations:^{
+    ldImageAlignmentView.imageVerticalAlignment = LDImageVerticalAlignmentCenter;
+    ldImageAlignmentView.imageHorizontalAlignment= LDImageHorizontalAlignmentLeft;
+    ldImageAlignmentView.imageContentMode = LDImageContentModeScaleToFill;
+}];
+```

--- a/Sources/LDAlignmentImageView.h
+++ b/Sources/LDAlignmentImageView.h
@@ -1,5 +1,16 @@
 //
 //  LDImageView.h
+//  AutoLayout
+//
+//  Created by Aral Balkan on 11/10/2018.
+//  Copyright © 2018 Aral Balkan. All rights reserved.
+//
+
+#ifndef LDAlignmentImageView_h
+#define LDAlignmentImageView_h
+
+//
+//  LDImageView.h
 //  FotoGis
 //
 //  Created by Lucas Duda on 31.12.2016.
@@ -32,5 +43,8 @@ typedef enum LDImageContentMode{
 @property (nonatomic) LDImageVerticalAlignment imageVerticalAlignment;
 @property (nonatomic) LDImageHorizontalAlignment imageHorizontalAlignment;
 @property (nonatomic) LDImageContentMode imageContentMode;
+@property (nonatomic) UIImage* correctImage;
 
 @end
+
+#endif /* LDAlignmentImageView_h */

--- a/Sources/LDAlignmentImageView.m
+++ b/Sources/LDAlignmentImageView.m
@@ -1,5 +1,5 @@
 //
-//  LDImageView.m
+//  LDAlignmentImageView.m
 //  FotoGis
 //
 //  Created by Lucas Duda on 31.12.2016.
@@ -33,7 +33,7 @@
         _innerImageView = tmp;
         
         self.contentMode = [super contentMode];
-        self.image = [super image];
+        self.image = nil;
     }
     
     return self;
@@ -50,45 +50,45 @@
     CGFloat imageViewHeight;
     
     // compute scale factor for imageView
-    CGFloat widthScaleFactor = CGRectGetWidth(self.frame) / self.image.size.width;
-    CGFloat heightScaleFactor = CGRectGetHeight(self.frame) / self.image.size.height;
+    CGFloat widthScaleFactor = CGRectGetWidth(self.frame) / self.correctImage.size.width;
+    CGFloat heightScaleFactor = CGRectGetHeight(self.frame) / self.correctImage.size.height;
     
     //calculate size
     if (_imageContentMode == LDImageContentModeScaleAspectFill) {
         if (widthScaleFactor > heightScaleFactor) {
-            imageViewWidth = self.image.size.width * widthScaleFactor;
-            imageViewHeight = self.image.size.height * widthScaleFactor;
+            imageViewWidth = self.correctImage.size.width * widthScaleFactor;
+            imageViewHeight = self.correctImage.size.height * widthScaleFactor;
         } else {
-            imageViewWidth = self.image.size.width * heightScaleFactor;
-            imageViewHeight = self.image.size.height * heightScaleFactor;
+            imageViewWidth = self.correctImage.size.width * heightScaleFactor;
+            imageViewHeight = self.correctImage.size.height * heightScaleFactor;
         }
     } else if (_imageContentMode == LDImageContentModeScaleAspectFit){
         if (widthScaleFactor < heightScaleFactor) {
             imageViewWidth = self.bounds.size.width;
-            imageViewHeight = self.bounds.size.width * (self.image.size.height / self.image.size.width);
+            imageViewHeight = self.bounds.size.width * (self.correctImage.size.height / self.correctImage.size.width);
         } else {
-            imageViewWidth =  self.bounds.size.height * (self.image.size.width / self.image.size.height);
+            imageViewWidth =  self.bounds.size.height * (self.correctImage.size.width / self.correctImage.size.height);
             imageViewHeight = self.bounds.size.height;
         }
     } else if (_imageContentMode == LDImageContentModeScaleToFill){
         imageViewWidth = self.bounds.size.width;
         imageViewHeight = self.bounds.size.height;
     } else if (_imageContentMode == LDImageContentModeOriginalSize){
-        imageViewWidth = self.image.size.width;
-        imageViewHeight = self.image.size.height;
+        imageViewWidth = self.correctImage.size.width;
+        imageViewHeight = self.correctImage.size.height;
     }
     
     //calculate position
     //x
     switch (self.imageHorizontalAlignment) {
-        case LDImageHorizontalAlignmentLeft:
+            case LDImageHorizontalAlignmentLeft:
             break;
             
-        case LDImageHorizontalAlignmentCenter:
+            case LDImageHorizontalAlignmentCenter:
             imageViewXOrigin += (self.frame.size.width - imageViewWidth) / 2.0;
             break;
             
-        case LDImageHorizontalAlignmentRight:
+            case LDImageHorizontalAlignmentRight:
             imageViewXOrigin += self.frame.size.width - imageViewWidth;
             break;
             
@@ -99,14 +99,14 @@
     
     //y
     switch (self.imageVerticalAlignment) {
-        case LDImageVerticalAlignmentTop:
+            case LDImageVerticalAlignmentTop:
             break;
             
-        case LDImageVerticalAlignmentCenter:
+            case LDImageVerticalAlignmentCenter:
             imageViewYOrigin += (self.frame.size.height - imageViewHeight) / 2.0;
             break;
             
-        case LDImageVerticalAlignmentBottom:
+            case LDImageVerticalAlignmentBottom:
             imageViewYOrigin += self.frame.size.height - imageViewHeight;
             break;
             
@@ -114,12 +114,11 @@
             imageViewYOrigin += (self.frame.size.height - imageViewHeight) / 2.0;
             break;
     }
-
+    
     self.innerImageView.frame = CGRectMake(imageViewXOrigin,
                                            imageViewYOrigin,
                                            imageViewWidth,
                                            imageViewHeight);
-
 }
 
 
@@ -148,55 +147,55 @@
 - (void)setContentMode:(UIViewContentMode)contentMode{
     
     switch (contentMode) {
-        case UIViewContentModeScaleToFill:
+            case UIViewContentModeScaleToFill:
             _imageContentMode = LDImageContentModeScaleToFill;
             break;
             
-        case UIViewContentModeScaleAspectFill:
+            case UIViewContentModeScaleAspectFill:
             _imageContentMode = LDImageContentModeScaleAspectFill;
             break;
             
-        case UIViewContentModeScaleAspectFit:
+            case UIViewContentModeScaleAspectFit:
             _imageContentMode = LDImageContentModeScaleAspectFit;
             break;
             
-        case UIViewContentModeTop:
+            case UIViewContentModeTop:
             _imageVerticalAlignment = LDImageVerticalAlignmentTop;
             break;
             
-        case UIViewContentModeCenter:
+            case UIViewContentModeCenter:
             _imageVerticalAlignment = LDImageVerticalAlignmentCenter;
             _imageHorizontalAlignment = LDImageHorizontalAlignmentCenter;
             break;
             
-        case UIViewContentModeBottom:
+            case UIViewContentModeBottom:
             _imageVerticalAlignment = LDImageVerticalAlignmentBottom;
             break;
             
-        case UIViewContentModeLeft:
+            case UIViewContentModeLeft:
             _imageHorizontalAlignment = LDImageHorizontalAlignmentLeft;
             break;
             
-        case UIViewContentModeRight:
+            case UIViewContentModeRight:
             _imageHorizontalAlignment = LDImageHorizontalAlignmentRight;
             break;
             
-        case UIViewContentModeTopLeft:
+            case UIViewContentModeTopLeft:
             _imageHorizontalAlignment = LDImageHorizontalAlignmentLeft;
             _imageVerticalAlignment = LDImageVerticalAlignmentTop;
             break;
             
-        case UIViewContentModeTopRight:
+            case UIViewContentModeTopRight:
             _imageHorizontalAlignment = LDImageHorizontalAlignmentRight;
             _imageVerticalAlignment = LDImageVerticalAlignmentTop;
             break;
             
-        case UIViewContentModeBottomLeft:
+            case UIViewContentModeBottomLeft:
             _imageHorizontalAlignment = LDImageHorizontalAlignmentLeft;
             _imageVerticalAlignment = LDImageVerticalAlignmentBottom;
             break;
             
-        case UIViewContentModeBottomRight:
+            case UIViewContentModeBottomRight:
             _imageHorizontalAlignment = LDImageHorizontalAlignmentRight;
             _imageVerticalAlignment = LDImageVerticalAlignmentBottom;
             break;
@@ -208,22 +207,22 @@
     [self setNeedsDisplay];
 }
 
-- (void)setImage:(UIImage *)image{
+- (void)setCorrectImage:(UIImage *)image{
     
     self.innerImageView.image = image;
     [self layoutSubviews];
 }
 
-- (UIImage *)image{
+- (UIImage *)correctImage{
     return self.innerImageView.image;
 }
 
 /*
-// Only override drawRect: if you perform custom drawing.
-// An empty implementation adversely affects performance during animation.
-- (void)drawRect:(CGRect)rect {
-    // Drawing code
-}
-*/
+ // Only override drawRect: if you perform custom drawing.
+ // An empty implementation adversely affects performance during animation.
+ - (void)drawRect:(CGRect)rect {
+ // Drawing code
+ }
+ */
 
 @end


### PR DESCRIPTION
Breaking change: must use correctImage property instead of image property.